### PR TITLE
Sample Google OAuth

### DIFF
--- a/github/src/main/java/com/example/SocialApplication.java
+++ b/github/src/main/java/com/example/SocialApplication.java
@@ -134,24 +134,33 @@ public class SocialApplication extends WebSecurityConfigurerAdapter {
 		return new ClientResources();
 	}
 
+	@Bean
+	@ConfigurationProperties("google")
+	ClientResources google() {
+		return new ClientResources();
+	}
+
 	private Filter ssoFilter() {
 		CompositeFilter filter = new CompositeFilter();
 		List<Filter> filters = new ArrayList<>();
 		filters.add(ssoFilter(facebook(), "/login/facebook"));
 		filters.add(ssoFilter(github(), "/login/github"));
+		filters.add(ssoFilter(google(), "/login/google"));
 		filter.setFilters(filters);
 		return filter;
 	}
 
 	private Filter ssoFilter(ClientResources client, String path) {
-		OAuth2ClientAuthenticationProcessingFilter facebookFilter = new OAuth2ClientAuthenticationProcessingFilter(
+		OAuth2ClientAuthenticationProcessingFilter oAuth2Filter = new OAuth2ClientAuthenticationProcessingFilter(
 				path);
-		OAuth2RestTemplate facebookTemplate = new OAuth2RestTemplate(client.getClient(),
+		OAuth2RestTemplate oAuth2RestTemplate = new OAuth2RestTemplate(client.getClient(),
 				oauth2ClientContext);
-		facebookFilter.setRestTemplate(facebookTemplate);
-		facebookFilter.setTokenServices(new UserInfoTokenServices(
-				client.getResource().getUserInfoUri(), client.getClient().getClientId()));
-		return facebookFilter;
+		oAuth2Filter.setRestTemplate(oAuth2RestTemplate);
+		UserInfoTokenServices userInfoTokenServices = new UserInfoTokenServices(
+				client.getResource().getUserInfoUri(), client.getClient().getClientId());
+		userInfoTokenServices.setRestTemplate(oAuth2RestTemplate);
+		oAuth2Filter.setTokenServices(userInfoTokenServices);
+		return oAuth2Filter;
 	}
 
 	private Filter csrfHeaderFilter() {

--- a/github/src/main/resources/application.yml
+++ b/github/src/main/resources/application.yml
@@ -27,6 +27,19 @@ github:
   resource:
     userInfoUri: https://api.github.com/user
 
+google:
+  client:
+    clientId: 1071160065194-3556m2cmnlacgqo9qfjb2089f0aetb31.apps.googleusercontent.com
+    clientSecret: Hmw1APyVk7tLVcTTONh3pOhm
+    accessTokenUri: https://www.googleapis.com/oauth2/v3/token
+    userAuthorizationUri: https://accounts.google.com/o/oauth2/auth
+    authenticationScheme: query
+    scope:
+      - email
+      - profile
+  resource:
+    userInfoUri: https://www.googleapis.com/oauth2/v2/userinfo
+
 logging:
   level:
     org.springframework.security: DEBUG

--- a/github/src/main/resources/static/index.html
+++ b/github/src/main/resources/static/index.html
@@ -22,6 +22,9 @@
 		<div>
 			With Github: <a href="/login/github">click here</a>
 		</div>
+		<div>
+			With Google: <a href="/login/google">click here</a>
+		</div>
 	</div>
 	<div class="container" ng-show="home.authenticated">
 		Logged in as: <span ng-bind="home.user"></span>


### PR DESCRIPTION
I've extended the `github` example to include Google's OAuth2.  I determined that by supplying the `OAuth2RestTemplate` to the `UserInfoTokenServices` I was able to get `AuthenticationScheme.query` used when retrieving the User Info.  Applying the change to all `ssoFilter()` requests didn't seem to have any negative consequences but I could very well be missing something and would appreciate any feedback.

I've committed my own `clientId` and `clientSecret` that I've only used for this purpose, not sure what additional ramifications there may be for doing so.

Note that I did not make any changes to the `TokenType` (i.e. from `Bearer` to `bearer`) as mentioned elsewhere on the internets.