### PR TITLE
`@ConfigurationProperties` bean must be public

### DIFF
--- a/auth-server/README.adoc
+++ b/auth-server/README.adoc
@@ -72,13 +72,13 @@ before, but a single method for each provider:
 ----
 @Bean
 @ConfigurationProperties("github")
-ClientResources github() {
+public ClientResources github() {
   return new ClientResources();
 }
 
 @Bean
 @ConfigurationProperties("facebook")
-ClientResources facebook() {
+public ClientResources facebook() {
   return new ClientResources();
 }
 ----

--- a/auth-server/src/main/java/com/example/SocialApplication.java
+++ b/auth-server/src/main/java/com/example/SocialApplication.java
@@ -106,13 +106,13 @@ public class SocialApplication extends WebSecurityConfigurerAdapter {
 
 	@Bean
 	@ConfigurationProperties("github")
-	ClientResources github() {
+	public ClientResources github() {
 		return new ClientResources();
 	}
 
 	@Bean
 	@ConfigurationProperties("facebook")
-	ClientResources facebook() {
+	public ClientResources facebook() {
 		return new ClientResources();
 	}
 

--- a/github/README.adoc
+++ b/github/README.adoc
@@ -72,13 +72,13 @@ supplemented with similar methods `github()` and `githubResource()`:
 ----
 @Bean
 @ConfigurationProperties("github.client")
-OAuth2ProtectedResourceDetails github() {
+public OAuth2ProtectedResourceDetails github() {
 	return new AuthorizationCodeResourceDetails();
 }
 
 @Bean
 @ConfigurationProperties("github.resource")
-ResourceServerProperties githubResource() {
+public ResourceServerProperties githubResource() {
 	return new ResourceServerProperties();
 }
 ----

--- a/github/src/main/java/com/example/SocialApplication.java
+++ b/github/src/main/java/com/example/SocialApplication.java
@@ -106,13 +106,13 @@ public class SocialApplication extends WebSecurityConfigurerAdapter {
 
 	@Bean
 	@ConfigurationProperties("github")
-	ClientResources github() {
+	public ClientResources github() {
 		return new ClientResources();
 	}
 
 	@Bean
 	@ConfigurationProperties("facebook")
-	ClientResources facebook() {
+	public ClientResources facebook() {
 		return new ClientResources();
 	}
 

--- a/manual/README.adoc
+++ b/manual/README.adoc
@@ -83,7 +83,7 @@ the filter also needs to know about the client registration with Facebook:
 
   @Bean
   @ConfigurationProperties("facebook.client")
-  OAuth2ProtectedResourceDetails facebook() {
+  public OAuth2ProtectedResourceDetails facebook() {
     return new AuthorizationCodeResourceDetails();
   }
 ----
@@ -96,7 +96,7 @@ info endpoint is in Facebook:
 ----
   @Bean
   @ConfigurationProperties("facebook.resource")
-  ResourceServerProperties facebookResource() {
+  public ResourceServerProperties facebookResource() {
     return new ResourceServerProperties();
   }
 ----

--- a/manual/src/main/java/com/example/SocialApplication.java
+++ b/manual/src/main/java/com/example/SocialApplication.java
@@ -91,13 +91,13 @@ public class SocialApplication extends WebSecurityConfigurerAdapter {
 
 	@Bean
 	@ConfigurationProperties("facebook.client")
-	OAuth2ProtectedResourceDetails facebook() {
+	public OAuth2ProtectedResourceDetails facebook() {
 		return new AuthorizationCodeResourceDetails();
 	}
 
 	@Bean
 	@ConfigurationProperties("facebook.resource")
-	ResourceServerProperties facebookResource() {
+	public ResourceServerProperties facebookResource() {
 		return new ResourceServerProperties();
 	}
 


### PR DESCRIPTION
The code sample for `@ConfigurationProperties` beans are package
protected (it's missing the `public` keyword). Metadata will be generated
only if the bean is public.

This commit fixes both the code and the samples.