### PR TITLE
Generates useful metadata

### DIFF
--- a/auth-server/README.adoc
+++ b/auth-server/README.adoc
@@ -51,10 +51,13 @@ the `OAuth2ProtectedResourceDetails` and the
 ----
 class ClientResources {
 
-  private OAuth2ProtectedResourceDetails client = new AuthorizationCodeResourceDetails();
+  @NestedConfigurationProperty
+  private AuthorizationCodeResourceDetails client = new AuthorizationCodeResourceDetails();
+
+  @NestedConfigurationProperty
   private ResourceServerProperties resource = new ResourceServerProperties();
 
-  public OAuth2ProtectedResourceDetails getClient() {
+  public AuthorizationCodeResourceDetails getClient() {
     return client;
   }
 
@@ -63,6 +66,10 @@ class ClientResources {
   }
 }
 ----
+
+NOTE: the wrapper uses `@NestedConfigurationProperty` to instructs the annotation
+processor to crawl that type for meta-data as well since it does not represents
+a single value but a complete nested type.
 
 With this wrapper in place we can use the same YAML configuration as
 before, but a single method for each provider:

--- a/auth-server/src/main/java/com/example/SocialApplication.java
+++ b/auth-server/src/main/java/com/example/SocialApplication.java
@@ -29,6 +29,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.ResourceServerProperties;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.UserInfoTokenServices;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -138,10 +139,14 @@ public class SocialApplication extends WebSecurityConfigurerAdapter {
 }
 
 class ClientResources {
-	private OAuth2ProtectedResourceDetails client = new AuthorizationCodeResourceDetails();
+
+	@NestedConfigurationProperty
+	private AuthorizationCodeResourceDetails client = new AuthorizationCodeResourceDetails();
+
+	@NestedConfigurationProperty
 	private ResourceServerProperties resource = new ResourceServerProperties();
 
-	public OAuth2ProtectedResourceDetails getClient() {
+	public AuthorizationCodeResourceDetails getClient() {
 		return client;
 	}
 

--- a/github/README.adoc
+++ b/github/README.adoc
@@ -72,7 +72,7 @@ supplemented with similar methods `github()` and `githubResource()`:
 ----
 @Bean
 @ConfigurationProperties("github.client")
-public OAuth2ProtectedResourceDetails github() {
+public AuthorizationCodeResourceDetails github() {
 	return new AuthorizationCodeResourceDetails();
 }
 

--- a/github/src/main/java/com/example/SocialApplication.java
+++ b/github/src/main/java/com/example/SocialApplication.java
@@ -29,6 +29,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.ResourceServerProperties;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.UserInfoTokenServices;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -140,10 +141,14 @@ public class SocialApplication extends WebSecurityConfigurerAdapter {
 }
 
 class ClientResources {
-	private OAuth2ProtectedResourceDetails client = new AuthorizationCodeResourceDetails();
+
+	@NestedConfigurationProperty
+	private AuthorizationCodeResourceDetails client = new AuthorizationCodeResourceDetails();
+
+	@NestedConfigurationProperty
 	private ResourceServerProperties resource = new ResourceServerProperties();
 
-	public OAuth2ProtectedResourceDetails getClient() {
+	public AuthorizationCodeResourceDetails getClient() {
 		return client;
 	}
 

--- a/manual/README.adoc
+++ b/manual/README.adoc
@@ -83,7 +83,7 @@ the filter also needs to know about the client registration with Facebook:
 
   @Bean
   @ConfigurationProperties("facebook.client")
-  public OAuth2ProtectedResourceDetails facebook() {
+  public AuthorizationCodeResourceDetails facebook() {
     return new AuthorizationCodeResourceDetails();
   }
 ----

--- a/manual/src/main/java/com/example/SocialApplication.java
+++ b/manual/src/main/java/com/example/SocialApplication.java
@@ -91,7 +91,7 @@ public class SocialApplication extends WebSecurityConfigurerAdapter {
 
 	@Bean
 	@ConfigurationProperties("facebook.client")
-	public OAuth2ProtectedResourceDetails facebook() {
+	public AuthorizationCodeResourceDetails facebook() {
 		return new AuthorizationCodeResourceDetails();
 	}
 


### PR DESCRIPTION
Prior to this commit, the generated metadata were mostly empty and did
not really validate what was instructed in the guide.

One reason was that `ClientResources` was treating the underlying types
as mono value object so no meta-data were generated on them. The other
reason was that the concrete type wasn't returned and the interface has
no setter so no properties were found either.

This commit fixes the infrastructure so that the generated metadata is
valid.