### PR TITLE
Error page documentation fix

### DIFF
--- a/custom-error/README.adoc
+++ b/custom-error/README.adoc
@@ -66,7 +66,7 @@ $.ajax({
     }
   }
 });
- ----
+----
 
 The authentication function checks the browser location when it loads
 and if it finds a URL with "error=true" in it, the flag is set.


### PR DESCRIPTION
Last section of the documentation is broken.
A pesky space prevented the .adoc from rendering properly.