### PR TITLE
Fixes to support several OAuth 2 Grants

### DIFF
--- a/auth-server/README.adoc
+++ b/auth-server/README.adoc
@@ -384,6 +384,6 @@ Refreshing an Access Token is working.
 
 Checking an Access Token is working.
 
-Authorization Code Grant is NOT working.
+Authorization Code Grant is working.
 
 Log-in with Resource Owner Credentials is also NOT working.

--- a/auth-server/README.adoc
+++ b/auth-server/README.adoc
@@ -130,6 +130,11 @@ security:
       client-secret: acmesecret
       scope: read,write
       auto-approve-scopes: '.*'
+    authorization:
+      check-token-access: isAuthenticated()
+  user:
+    name: acmeuser
+    password: acmeuserpassword
 ----
 
 This client is the equivalent of the `facebook.client{star}` and
@@ -148,8 +153,16 @@ add an explicit approval step to the token grant we would need to
 provide a UI replacing the whitelabel version (at
 `/oauth/confirm_access`).
 
-To finish the Authorization Server we just need to provide security 
-configuration for its UI. In fact there isn't much of a user 
+NOTE: We enable the check_token endpoint with the configuration
+"check-token-access: isAuthenticated()". We need this endpoint to
+validate the Access Tokens from an external application (or website).
+
+NOTE: If we don't provide user credentials Spring Boot creates new
+random credentials on every application start. Therefore we provide
+them and can use the OAuth 2 Resource Owner Password Credentials Grant.
+
+To finish the Authorization Server we just need to provide security
+configuration for its UI. In fact there isn't much of a user
 interface in this simple app, but we still need to protect the
 `/oauth/authorize` endpoint, and make sure that the home page
 with the "Login" buttons is visible. That's why we have this
@@ -200,7 +213,7 @@ $ curl acme:acmesecret@localhost:8080/oauth/token -d grant_type=password -d user
 
 where "..." should be replaced with the actual password. This is
 called a "password" grant, where you exchange a username and password
-for an access token. 
+for an access token.
 
 Password grant is also mainly useful for testing, but can be
 appropriate for a native or mobile application, when you have a local
@@ -360,3 +373,17 @@ is complete control returns to the test client, the local access token
 is granted and authentication is complete (you should see a "Hello"
 message in your browser). If you are already authenticated with Github
 or Facebook you may not even notice the remote authentication.
+
+== OAuth2 Authorization Server Features
+
+Client Credentials Grant is working.
+
+Resource Owner Password Credentials Grant is working.
+
+Refreshing an Access Token is working.
+
+Checking an Access Token is working.
+
+Authorization Code Grant is NOT working.
+
+Log-in with Resource Owner Credentials is also NOT working.

--- a/auth-server/src/main/resources/application.yml
+++ b/auth-server/src/main/resources/application.yml
@@ -5,6 +5,11 @@ security:
       client-secret: acmesecret
       scope: read,write
       auto-approve-scopes: '.*'
+    authorization:
+      check-token-access: isAuthenticated()
+  user:
+    name: acmeuser
+    password: acmeuserpassword
 
 facebook:
   client:

--- a/auth-server/src/test/java/com/example/ClientCredentialsGrantTest.java
+++ b/auth-server/src/test/java/com/example/ClientCredentialsGrantTest.java
@@ -1,0 +1,121 @@
+package com.example;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class ClientCredentialsGrantTest {
+
+   private ObjectMapper jsonMapper = new ObjectMapper();
+   private TypeReference<Map<String, Object>> objectMapReference = new TypeReference<Map<String, Object>>() { };
+
+   @Value("${security.oauth2.client.client-id}")
+   private String clientId;
+   @Value("${security.oauth2.client.client-secret}")
+   private String clientSecret;
+   @Value("${security.oauth2.client.scope}")
+   private String scope;
+   private String[] scopes;
+
+   @Autowired
+   private TestRestTemplate restTemplate;
+
+   @Before
+   public void setUp() {
+
+      scopes = scope.split("\\s*,\\s*");
+   }
+
+   @Test
+   public void test() throws Exception {
+
+      MultiValueMap<String, String> requestFormMap;
+      ResponseEntity<String> response;
+      Map<String, Object> responseMap;
+      HttpHeaders headers = new HttpHeaders();
+      headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+      // ----- Client Credentials Grant -----
+      // If you provide your own client credentials in application.yml, you can use this Grant with those credentials.
+      // security:
+      //   oauth2:
+      //     client:
+      //       client-id: acme
+      //       client-secret: acmesecret
+
+      requestFormMap = new LinkedMultiValueMap<>();
+      requestFormMap.add("grant_type", "client_credentials");
+      requestFormMap.add("scope", scopes[0]);
+
+      response = this.restTemplate
+         .withBasicAuth(clientId, clientSecret)
+         .postForEntity("/oauth/token", new HttpEntity<>(requestFormMap, headers) , String.class);
+
+      Assert.assertEquals(200, response.getStatusCodeValue());
+
+      responseMap = jsonMapper.readValue(response.getBody(), this.objectMapReference);
+      /*
+      {
+        "access_token":"2f1cd8a7-89ab-4168-b4a9-fb1ef52e8e71",
+        "token_type":"bearer",
+        "expires_in":43199,
+        "scope":"write"
+      }
+       */
+
+      Assert.assertNotNull(responseMap.get("access_token"));
+      Assert.assertEquals("bearer", responseMap.get("token_type"));
+      Assert.assertTrue((int) responseMap.get("expires_in") > 1000);
+      Assert.assertEquals(scopes[0], responseMap.get("scope"));
+
+      String accessToken = (String) responseMap.get("access_token");
+
+      // ----- Check Access Token -----
+      // Check Access Token is available when you grant access to the check_token endpoint in application.yml.
+      // security:
+      //   oauth2:
+      //     authorization:
+      //       check-token-access: isAuthenticated()
+
+      response = this.restTemplate
+         .withBasicAuth(clientId, clientSecret)
+         .getForEntity("/oauth/check_token?token={token}" , String.class, accessToken);
+
+      Assert.assertEquals(200, response.getStatusCodeValue());
+
+      responseMap = jsonMapper.readValue(response.getBody(), this.objectMapReference);
+      /*
+      {
+        "scope":[ "write" ],
+        "exp":1522440288,
+        "authorities":[ "ROLE_USER" ],
+        "client_id":"acme"
+      }
+       */
+
+      Assert.assertEquals(scopes[0], List.class.cast(responseMap.get("scope")).get(0));
+      Assert.assertTrue(Long.compare(Instant.now().getEpochSecond(), ((Integer) responseMap.get("exp"))) < 0);
+      Assert.assertEquals("ROLE_USER", List.class.cast(responseMap.get("authorities")).get(0));
+      Assert.assertEquals(clientId, responseMap.get("client_id"));
+   }
+}

--- a/auth-server/src/test/java/com/example/ResourceOwnerPasswordCredentialsGrantTest.java
+++ b/auth-server/src/test/java/com/example/ResourceOwnerPasswordCredentialsGrantTest.java
@@ -125,7 +125,5 @@ public class ResourceOwnerPasswordCredentialsGrantTest {
       Assert.assertEquals(refreshToken, responseMap.get("refresh_token"));
       Assert.assertTrue((int) responseMap.get("expires_in") > 1000);
       Assert.assertEquals(scopes[0], responseMap.get("scope"));
-
-      // ----- TODO Check Access Token -----
    }
 }

--- a/auth-server/src/test/java/com/example/ResourceOwnerPasswordCredentialsGrantTest.java
+++ b/auth-server/src/test/java/com/example/ResourceOwnerPasswordCredentialsGrantTest.java
@@ -1,0 +1,131 @@
+package com.example;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import java.util.Map;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class ResourceOwnerPasswordCredentialsGrantTest {
+
+   private ObjectMapper jsonMapper = new ObjectMapper();
+   private TypeReference<Map<String, Object>> objectMapReference = new TypeReference<Map<String, Object>>() { };
+
+   @Value("${security.oauth2.client.client-id}")
+   private String clientId;
+   @Value("${security.oauth2.client.client-secret}")
+   private String clientSecret;
+   @Value("${security.user.name}")
+   private String userName;
+   @Value("${security.user.password}")
+   private String userPassword;
+   @Value("${security.oauth2.client.scope}")
+   private String scope;
+   private String[] scopes;
+
+   @Autowired
+   private TestRestTemplate restTemplate;
+
+   @Before
+   public void setUp() {
+
+      scopes = scope.split("\\s*,\\s*");
+   }
+
+   @Test
+   public void test() throws Exception {
+
+      MultiValueMap<String, String> requestFormMap;
+      ResponseEntity<String> response;
+      Map<String, Object> responseMap;
+      HttpHeaders headers = new HttpHeaders();
+      headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+      // ----- Resource Owner Password Credentials Grant -----
+      // Spring Boot creates new random user credentials on every application start, unless you provide your own
+      // user credentials in application.yml, in which case you can use this Grant with those credentials.
+      // security:
+      //   user:
+      //     name: acmeuser
+      //     password: acmeuserpassword
+
+      requestFormMap = new LinkedMultiValueMap<>(4);
+      requestFormMap.add("grant_type", "password");
+      requestFormMap.add("scope", scopes[0]);
+      requestFormMap.add("username", userName);
+      requestFormMap.add("password", userPassword);
+
+      response = this.restTemplate
+         .withBasicAuth(clientId, clientSecret)
+         .postForEntity("/oauth/token", new HttpEntity<>(requestFormMap, headers), String.class);
+
+      Assert.assertEquals(200, response.getStatusCodeValue());
+
+      responseMap = jsonMapper.readValue(response.getBody(), this.objectMapReference);
+      /*
+      {
+        "access_token":"2fd811d9-a3e4-4e91-916a-58854ac96a3a",
+        "token_type":"bearer",
+        "refresh_token":"498e0caa-5337-44eb-a6e9-e0def946621f",
+        "expires_in":43199,
+        "scope":"write"
+      }
+       */
+
+      Assert.assertNotNull(responseMap.get("access_token"));
+      Assert.assertEquals("bearer", responseMap.get("token_type"));
+      Assert.assertNotNull(responseMap.get("refresh_token"));
+      Assert.assertTrue((int) responseMap.get("expires_in") > 1000);
+      Assert.assertEquals(scopes[0], responseMap.get("scope"));
+
+      String refreshToken = (String) responseMap.get("refresh_token");
+
+      // ----- Renew Access Token with Refresh Token -----
+
+      requestFormMap = new LinkedMultiValueMap<>(3);
+      requestFormMap.add("grant_type", "refresh_token");
+      requestFormMap.add("scope", scopes[0]);
+      requestFormMap.add("refresh_token", refreshToken);
+
+      response = this.restTemplate
+         .withBasicAuth(clientId, clientSecret)
+         .postForEntity("/oauth/token", new HttpEntity<>(requestFormMap, headers), String.class);
+
+      Assert.assertEquals(200, response.getStatusCodeValue());
+
+      responseMap = jsonMapper.readValue(response.getBody(), this.objectMapReference);
+      /*
+      {
+        "access_token":"5adad4cd-23c6-4174-8f5e-7e1906b54f60",
+        "token_type":"bearer",
+        "refresh_token":"498e0caa-5337-44eb-a6e9-e0def946621f",
+        "expires_in":43199,
+        "scope":"write"
+      }
+       */
+
+      Assert.assertNotNull(responseMap.get("access_token"));
+      Assert.assertEquals("bearer", responseMap.get("token_type"));
+      Assert.assertEquals(refreshToken, responseMap.get("refresh_token"));
+      Assert.assertTrue((int) responseMap.get("expires_in") > 1000);
+      Assert.assertEquals(scopes[0], responseMap.get("scope"));
+
+      // ----- TODO Check Access Token -----
+   }
+}


### PR DESCRIPTION
There are some fixes required to support some OAuth 2 Grants.
Note: Even after the fixes this is NOT a fully-fledged OAuth 2 Authorization Server, because some (verry important) features are already not working, like Authorization Code Grant and Login with Resource Owner Credentials.