### PR TITLE
fixed bug associated with missing dependency JAXB-API

### DIFF
--- a/auth-server/pom.xml
+++ b/auth-server/pom.xml
@@ -71,6 +71,20 @@
             <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>
         </dependency>
+
+          <!-- https://stackoverflow.com/questions/48986999 -->
+          <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+          </dependency>
+          <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>                               
+            <version>2.3.2</version>
+          </dependency>
+          <!-- JAXB-API has not been found on module path or classpath -->
+
     </dependencies>
 
     <build>


### PR DESCRIPTION
Tests currently failing. Added a JAXB-API dependency. Tests now passing for auth-server.

```
Caused by: org.springframework.beans.BeanInstantiationException: Failed to inst\
antiate [javax.servlet.Filter]: Factory method 'springSecurityFilterChain' thre\
w exception; nested exception is java.lang.NoClassDefFoundError: javax/xml/bind\
/JAXBException                                                                  
Caused by: java.lang.NoClassDefFoundError: javax/xml/bind/JAXBException
Caused by: java.lang.ClassNotFoundException: javax.xml.bind.JAXBException
```