### PR TITLE
'spring-security-oauth2-autoconfigure' version update

### DIFF
--- a/simple/README.adoc
+++ b/simple/README.adoc
@@ -108,7 +108,7 @@ we add the Spring Security OAuth2 dependency as well:
 <dependency>
 	<groupId>org.springframework.security.oauth.boot</groupId>
 	<artifactId>spring-security-oauth2-autoconfigure</artifactId>
-	<version>2.0.0.RELEASE</version>
+	<version>2.1.1.RELEASE</version>
 </dependency>
 ----
 

--- a/simple/pom.xml
+++ b/simple/pom.xml
@@ -39,7 +39,7 @@
 		<dependency>
 			<groupId>org.springframework.security.oauth.boot</groupId>
 			<artifactId>spring-security-oauth2-autoconfigure</artifactId>
-			<version>2.0.0.RELEASE</version>
+			<version>2.1.1.RELEASE</version>
 		</dependency>
 		<dependency>
 			<groupId>org.webjars</groupId>


### PR DESCRIPTION
Hello.
I am learning from 'https://spring.io/guides/tutorials/spring-boot-oauth2/#_social_login_simple' Guide.
Problems occur when writing code with reference to the Guide.
The error log is shown below.
----
Description:

The bean 'scopedTarget.oauth2ClientContext', defined in class path resource [org / springframework / boot / autoconfigure / security / oauth2 / client / OAuth2RestOperationsConfiguration $ SessionScopedConfiguration $ ClientContextConfiguration.class], could not be registered. A bean with that name has already been defined in org.springframework.security.oauth2.config.annotation.web.configuration.OAuth2ClientConfiguration $ OAuth2ClientContextConfiguration and overriding is disabled.
---
This is a problem that occurs below.
---
<groupId> org.springframework.security.oauth.boot </ groupId>
<artifactId> spring-security-oauth2-autoconfigure </ artifactId>
<version> 2.0.0.RELEASE </ version>
Details can be found in this issue 'https://github.com/spring-projects/spring-security-oauth2-boot/issues/51'

I updated guide.

thanks for reading.