### PR TITLE
URL Cleanup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 gem "guard"
 gem "guard-shell"

--- a/LICENSE.writing.txt
+++ b/LICENSE.writing.txt
@@ -1,1 +1,1 @@
-Except where otherwise noted, this work is licensed under http://creativecommons.org/licenses/by-nd/3.0/
+Except where otherwise noted, this work is licensed under https://creativecommons.org/licenses/by-nd/3.0/

--- a/README.adoc
+++ b/README.adoc
@@ -14,7 +14,7 @@ projects: [spring-security,spring-security-oauth,spring-boot]
 
 This guide shows you how to build a sample app doing various things
 with "social login" using https://tools.ietf.org/html/rfc6749[OAuth2]
-and http://projects.spring.io/spring-boot/[Spring Boot]. It starts
+and https://projects.spring.io/spring-boot/[Spring Boot]. It starts
 with a simple, single-provider single-sign on, and works up to a
 self-hosted OAuth2 Authorization Server with a choice of
 authentication providers (https://developers.facebook.com[Facebook] or

--- a/auth-server/README.adoc
+++ b/auth-server/README.adoc
@@ -190,7 +190,7 @@ users. To get a token on behalf of a user of our app we need to be
 able to authenticate the user. If you were watching the logs carefully
 when the app started up you would have seen a random password being
 logged for the default Spring Boot user (per the
-http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-security[Spring
+https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-security[Spring
 Boot User Guide]). You can use this password to get a token on behalf of the user with id "user":
 
 ```

--- a/overview.adoc
+++ b/overview.adoc
@@ -39,7 +39,7 @@ that you have at least a Facebook account if you want to log in and
 see the content). You can also run all the apps on the command line
 using `mvn spring-boot:run` or by building the jar file and running it
 with `mvn package` and `java -jar target/*.jar` (per the
-http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-first-application-run[Spring
+https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-first-application-run[Spring
 Boot docs] and other
 https://spring.io/guides/gs/spring-boot/[available
 documentation]). There is no need to install Maven if you use the

--- a/simple/README.adoc
+++ b/simple/README.adoc
@@ -9,7 +9,7 @@ autoconfiguration features in Spring Boot.
 
 First we need to create a Spring Boot application,
 which can be done in a number of ways. The easiest is to go to
-http://start.spring.io and generate an empty project (choosing the
+https://start.spring.io and generate an empty project (choosing the
 "Web" dependency as starting points). Equivalently do
 this on the command line:
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/ (301) with 2 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/ ([https](https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://creativecommons.org/licenses/by-nd/3.0/ with 1 occurrences migrated to:  
  https://creativecommons.org/licenses/by-nd/3.0/ ([https](https://creativecommons.org/licenses/by-nd/3.0/) result 200).
* [ ] http://projects.spring.io/spring-boot/ with 1 occurrences migrated to:  
  https://projects.spring.io/spring-boot/ ([https](https://projects.spring.io/spring-boot/) result 200).
* [ ] http://rubygems.org with 1 occurrences migrated to:  
  https://rubygems.org ([https](https://rubygems.org) result 200).
* [ ] http://start.spring.io with 1 occurrences migrated to:  
  https://start.spring.io ([https](https://start.spring.io) result 200).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8080 with 2 occurrences
* http://localhost:8080/me with 3 occurrences
* http://localhost:8080/oauth/authorize with 3 occurrences
* http://localhost:8080/oauth/token with 3 occurrences
* http://localhost:9999/client with 2 occurrences