### PR TITLE
Fix README.adoc client registration property

### DIFF
--- a/simple/README.adoc
+++ b/simple/README.adoc
@@ -122,13 +122,14 @@ Then, to make the link to GitHub, add the following to your `application.yml`:
 .application.yml
 [source,yaml]
 ----
-security:
-  oauth2:
-    client:
-      registration:
-        github:
-          clientId: github-client-id
-          clientSecret: github-client-secret
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          github:
+            clientId: github-client-id
+            clientSecret: github-client-secret
 # ...
 ----
 


### PR DESCRIPTION
Currently when we add the git-hub client registration, the property starts with `security.oauth2...`, but the property's name starts as spring.security.oauth2. 
Since the project is just created, the yml doesn't exits or is empty, so there is no base `spring:` to append the suggested property to.