### PR TITLE
Fix to add missing argument

### DIFF
--- a/custom-error/README.adoc
+++ b/custom-error/README.adoc
@@ -77,7 +77,7 @@ Then, you can add a simple `/error` controller, like this one:
 [source,java]
 ----
 @GetMapping("/error")
-public String error() {
+public String error(HttpServletRequest request) {
 	String message = (String) request.getSession().getAttribute("error.message");
 	request.getSession().removeAttribute("error.message");
 	return message;


### PR DESCRIPTION
Add missing argument for error method.

ref:
https://github.com/spring-guides/tut-spring-boot-oauth2/blob/5cc3b36f0bf8d2a9093a1378bfcc87c22901ed01/custom-error/src/main/java/com/example/SocialApplication.java#L97