### PR TITLE
Second header will be "Google"

### DIFF
--- a/two-providers/README.adoc
+++ b/two-providers/README.adoc
@@ -1,5 +1,5 @@
 [[_social_login_first_party]]
-= Login with GitHub
+= Login with Google
 
 In this section, you'll modify the <<_social_login_logout,logout>> app you built already, adding a sticker page so that the end-user can choose between multiple sets of credentials.
 


### PR DESCRIPTION
We logged in with Github at [simple](https://github.com/spring-guides/tut-spring-boot-oauth2/blob/main/simple/README.adoc) section, so I think that the header of this section will be "Google" not "Github"