### PR TITLE
Fixed typo on Two-providers topic.

### DIFF
--- a/two-providers/README.adoc
+++ b/two-providers/README.adoc
@@ -1,5 +1,5 @@
 [[_social_login_first_party]]
-= Login with GitHub
+= Login with Google
 
 In this section, you'll modify the <<_social_login_logout,logout>> app you built already, adding a sticker page so that the end-user can choose between multiple sets of credentials.
 


### PR DESCRIPTION
This part is related to adding Google as a new login source. So it should be `Login with Google`. 